### PR TITLE
Improvement: a help message when no argument is present

### DIFF
--- a/src/main/java/wm/vdr/autofishing/Executors.java
+++ b/src/main/java/wm/vdr/autofishing/Executors.java
@@ -18,7 +18,17 @@ public class Executors implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if(args.length == 0) {
-            return false;
+            String[] helpMessage = new String[]{
+                    "§7]§8----- §eAutoFishing §8-----§7[",
+                    "",
+                    "§a/autofishing toggle §7- §etoggle the auto fishing ability",
+                    "§a/autofishing give <player> §7- §egive the specific rod to someone",
+                    "§a/autofishing reload §7- §ereload the config file",
+                    "",
+                    "§7[§8-----------------------§7["
+            };
+            for (String helpMessageLine : helpMessage) sender.sendMessage(helpMessageLine);
+            return true;
         }
         if(args[0].equalsIgnoreCase("reload")) {
             if(!sender.hasPermission("autofishing.admin")) {


### PR DESCRIPTION
## Help message
When no argument is present

Instead of this ugly message appearing when you type `/autofishing`:
![image](https://github.com/WMGameLive/AutoFishing/assets/83401368/214692a0-daff-4911-9eeb-2e34a8c52cf5)

you are greeted to this:
![image](https://github.com/WMGameLive/AutoFishing/assets/83401368/cdafc1e5-0993-4553-9593-99e41a647ef9)

which is way more clear, and useful.